### PR TITLE
Add REDCapEmailList

### DIFF
--- a/common/CHANGELOG.md
+++ b/common/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 Documentation of release versions of `redcap-api`
 
+## 0.2.0
+
+* Adds `REDCapEmailList`
+
 ## 0.1.1
 
-Updates REDCap user role labels
+* Updates REDCap user role labels
 
 ## 0.1.0
 

--- a/common/src/python/redcap_api/BUILD
+++ b/common/src/python/redcap_api/BUILD
@@ -7,7 +7,7 @@ python_distribution(
     sdist=True,
     provides=python_artifact(
         name="redcap-api",
-        version="0.1.1",
+        version="0.2.0",
         description="Library for interacting with the REDCap API",
         author="NACC",
         author_email="nacchelp@uw.edu",

--- a/common/src/python/redcap_api/redcap_email_list.py
+++ b/common/src/python/redcap_api/redcap_email_list.py
@@ -1,0 +1,62 @@
+"""Handles REDCap email list."""
+
+from typing import Dict
+
+from .redcap_connection import (
+    REDCapConnectionError,
+    REDCapReportConnection,
+)
+from .redcap_parameter_store import REDCapReportParameters
+
+
+class REDCapEmailListError(Exception):
+    pass
+
+
+class REDCapEmailList:
+
+    def __init__(self, redcap_con: REDCapReportConnection,
+                 email_key: str) -> None:
+        """Pull email list from REDCap report.
+
+        Args:
+            redcap_con: The REDCapReportConnection
+            email_key: Name of header key which emails can be found under
+                in the REDCap Report
+        """
+        self.__redcap_con = redcap_con
+        self.__email_list = self.__pull_email_list_from_redcap(email_key)
+
+    @property
+    def email_list(self) -> Dict[str, Dict[str, str]]:
+        return self.__email_list
+
+    def __pull_email_list_from_redcap(
+            self, email_key: str) -> Dict[str, Dict[str, str]]:
+        """Pull email list from REDCap. Maps each email to the corresponding
+        record, and assumes each email is unique.
+
+        Args:
+            email_key: Name of header key which emails can be found under
+                in the REDCap Report
+        """
+        records = self.__redcap_con.get_report_records()
+
+        email_list = {}
+        for record in records:
+            email = record[email_key]
+            if email in email_list:
+                raise REDCapEmailListError(f"Duplicate email: {email}")
+            email_list[email] = record
+
+        return email_list
+
+    @staticmethod
+    def create(redcap_params: REDCapReportParameters,
+               email_key: str) -> "REDCapEmailList":
+        """Creates the REDCapEmailList."""
+        try:
+            redcap_con = REDCapReportConnection.create_from(redcap_params)
+            return REDCapEmailList(redcap_con=redcap_con, email_key=email_key)
+        except REDCapConnectionError as error:
+            raise REDCapEmailListError(error) from error

--- a/common/test/python/BUILD
+++ b/common/test/python/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests", )

--- a/common/test/python/test_redcap_email_list.py
+++ b/common/test/python/test_redcap_email_list.py
@@ -1,0 +1,55 @@
+"""Tests REDCapEmailList."""
+from typing import Dict, List
+
+import pytest
+from redcap_api.redcap_connection import REDCapReportConnection
+from redcap_api.redcap_email_list import REDCapEmailList
+
+
+@pytest.fixture(scope="function")
+def redcap_email_list():
+    """Fixture for REDCapEmailList."""
+    redcap_con = MockREDCapReportConnection(token="dummy-token",
+                                            url="dummy-url",
+                                            report_id=0)
+    return REDCapEmailList(redcap_con=redcap_con, email_key="email")
+
+
+class MockREDCapReportConnection(REDCapReportConnection):
+    """Mocks the REDCap connection for testing."""
+
+    def get_report_records(self) -> List[Dict[str, str]]:
+        """Mock getting report records."""
+        return [
+            {
+                "email": "dummy_email1@dummy.org",
+                "firstname": "Dummy1"
+            },
+            {
+                "email": "dummy_email2@dummy.org",
+                "firstname": "Dummy2"
+            },
+            {
+                "email": "dummy_email3@dummy.org",
+                "firstname": "Dummy3"
+            },
+        ]
+
+
+class TestREDCapEmailList:
+
+    def test_grabbed_email_list(self, redcap_email_list):
+        assert redcap_email_list.email_list == {
+            "dummy_email1@dummy.org": {
+                "email": "dummy_email1@dummy.org",
+                "firstname": "Dummy1",
+            },
+            "dummy_email2@dummy.org": {
+                "email": "dummy_email2@dummy.org",
+                "firstname": "Dummy2",
+            },
+            "dummy_email3@dummy.org": {
+                "email": "dummy_email3@dummy.org",
+                "firstname": "Dummy3",
+            },
+        }


### PR DESCRIPTION
Adds REDCapEmailList

Originally part of [this flywheel-gear-extensions PR to support emailing REDCap lists](https://github.com/naccdata/flywheel-gear-extensions/pull/243). Moved it to this API since categorically makes more sense here and we may need to support other tasks that require interaction with a REDCap email list, separate from gears.

This could probably also support adding to a REDCap email list, but for now it just pulls the emails. 